### PR TITLE
EPCDP-13: Added "applied" flag in configResponse

### DIFF
--- a/0006-cmx2cdp-protocol/README.md
+++ b/0006-cmx2cdp-protocol/README.md
@@ -105,9 +105,9 @@ _"config-response"_ message structure:
 - `contentType` (string, required) - content type of configuration, e.g.: json, protobuf.
 - `configId` (string, required) - unique identifier of endpoint configuration.
 - `statusCode` (number, required) - status code that holds meaningful information about the result of inbound message processing.
-- `reasonPhrase` (string, optional) - status code that holds meaningful information about the result of inbound message processing.
+- `reasonPhrase` (string, required) - status code that holds meaningful information about the result of inbound message processing.
 - `content` (byte[], optional) - content with configuration data.
-
+- `isApplied` (boolean, required) - shows if client has latest configuration (true if he does).
 Example:
 
 ```json
@@ -124,7 +124,8 @@ Example:
   "reasonPhrase": "OK",
   "content": {
     "bytes": "d2FpdXJoM2pmbmxzZGtjdjg3eTg3b3cz"
-  }
+  },
+  "isApplied": true
 }
 ```
 

--- a/0006-cmx2cdp-protocol/config-response.avsc
+++ b/0006-cmx2cdp-protocol/config-response.avsc
@@ -12,6 +12,7 @@
     {"name": "configId", "type": "string", "default":""},
     {"name": "statusCode", "type": "int", "default": 500},
     {"name": "reasonPhrase", "type": "string", "default":""},
-    {"name": "content", "type": ["null", "bytes"], "default": null}
+    {"name": "content", "type": ["null", "bytes"], "default": null},
+    {"name": "applied", "type": "boolean", "default": false}
  ]
 }


### PR DESCRIPTION
"applied" flag shows if current configuration is already used by client.