### PR TITLE
1/KP Define request/response pattern

### DIFF
--- a/0001-kaa-protocol/error-response.schema.json
+++ b/0001-kaa-protocol/error-response.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Kaa Protocol error response",
+  "type": "object",
+  "properties": {
+    "statusCode": {
+      "type": "integer",
+      "description": "Status code based on HTTP status codes"
+    },
+    "reasonPhrase": {
+      "type": "string",
+      "description": "A human-readable string explaining the cause of an error"
+    }
+  },
+  "required": [
+    "statusCode",
+    "reasonPhrase"
+  ],
+  "additionalProperties": false
+}


### PR DESCRIPTION
We have the same request/response pattern and similar message format
across multiple extensions (2/DCX, 5/CMX, 7/CMX, 10/EPMDX). It is
reasonable to define it in a single place, and also define it
semantics for CoAP.