### PR TITLE
7/CMX Adapt to 1/KP updates and general review

### DIFF
--- a/0007-configuration-management-extension/README.md
+++ b/0007-configuration-management-extension/README.md
@@ -5,21 +5,25 @@ status: raw
 editor: Alexey Shmalko <ashmalko@cybervisiontech.com>
 ---
 
-## Introduction
+# Introduction
 
 The Configuration Management Extension is a [Kaa Protocol](/0001-kaa-protocol/README.md) extension.
 
 It is intended to manage endpoint configuration distribution.
 
-## Requirements and constraints
-### Problems and possible solutions
+# Language
 
-1. _The server should know if a configuration has been applied by the endpoint._
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
+
+# Requirements and constraints
+## Problems and possible solutions
+
+1. _The server should know if a configuration has been applied by the endpoint._ <!-- TODO: why? add more reasoning -->
 
    Possible solutions:
-   - The client sends a publish message in a response to the new configuration provided by the server.
+   - The client sends a reply to the new configuration provided by the server.
 
-     This means the server is initiating a request. That does not work well for HTTP, CoAP, and other protocols that only support client-initiated requests.
+     This means the server is initiating a request. That does not work well for HTTP, CoAP, and other protocols that only support client-initiated requests, and is not recommended by 1/KP.
 
    - Introduce `/applied` resource, so the client sends an additional request once configuration is applied.
 
@@ -33,15 +37,24 @@ It is intended to manage endpoint configuration distribution.
     Possible solutions:
     - Send only updates. (e.g., using JSON Patch format, defined in [RFC 6902](https://tools.ietf.org/html/rfc6902).)
 
-## Use cases
+4. _Endpoint can actively reject a configuration._
 
-### UC1: Configuration request
+   Examples are:
+   - the endpoint is unable to process the configuration.
+   - the configuration is ill-formated, or pre-conditions are not met.
+
+   Possible solutions:
+   - Send the status result of the configuration application (either success or failure) back to the server.
+
+# Use cases
+
+## UC1: Configuration request
 Configuration delivery by request. The endpoint should be able to receive latest configuration from CMX by request.
 
-### UC2: Configuration push
+## UC2: Configuration push
 Configuration delivery is initiated by the server. The endpoint should receive latest configuration when it connects to the server if this configuration wasn't applied yet.
 
-## Design
+# Design
 The extension follows client-initiated request/response pattern described in 1/KP, which nicely maps to both MQTT and CoAP.
 
 There are two resources provided by the extension.
@@ -49,35 +62,50 @@ There are two resources provided by the extension.
 - `/<endpoint_token>/config/json` is used for subscribing and receiving a config.
 - `/<endpoint_token>/applied/json` is used for notifiying server of the currently active configuration.
 
-### Configuration identifier
+## Configuration identifier
 Configuration identifier is an opaque string, which uniquely identifies the configuration. The client SHOULD NOT assume the nature of identifiers.
 
-### Absent configuration
+## Absent configuration
 If an endpoint does not have a configuration assigned, its configuration is `null`, and the corresponding configuration identifier is an empty string (`""`).
 
-### Request/response
-The extension uses request/response pattern described in [1/KP](/0001-kaa-protocol/README.md) with observe extension. For MQTT, it is achieved by publishing multiple responses to the response path; for CoAP, it is achieved with the `Observe` option defined in [RFC 7641](https://tools.ietf.org/html/rfc7641).
+## Request/response
+The extension uses request/response pattern described in [1/KP](/0001-kaa-protocol/README.md) with observe extension. For MQTT, it is achieved by publishing multiple responses to the response topic; for CoAP, it is achieved with the `Observe` option defined in [RFC 7641](https://tools.ietf.org/html/rfc7641).
 
-### Config resource
-`/<endpoint_token>/config/json` resource is used for distributing the latest endpoint configuration.
+## Config resource
+Config resource is used for distributing the latest configuration to endpoints.
 
-A request is a JSON object with the following fields:
-- `id` (optional) - an opaque string used to match responses with requests. If absent, the client is not interested in matching responses with the requests.
-- `configId` (optional) - the identifier of the currently applied configuration. If not present, the absent configuration identifier (`""`) is assumed.
-- `observe` (optional) - identifies if the client is interested in observing the configuration.
+The config resource is a request/response resource with an observe extension which resides at the following resource path:
+```
+/<endpoint_token>/config
+```
 
-A response is a new configuration along with needed meta information. It is a JSON object with the following fields:
-- `id` (optional) - identifier of the corresponding request. MUST be the same as in the corresponding request.
-- `configId` (optional) - identifier of the `config`.
-- `config` (optional) - an arbitrary JSON type, representing the latest configuration available for the endpoint.
+### Request
+Request payload MUST be a UTF-8 encoded object with the JSON Scheme as defined in [config-request.schema.json](./config-request.schema.json) file.
 
-`configId` and `config` MUST come in a pair. If `configId` and `config` are absent in the response, that means configuration hasn't changed.
+```json
+{
+  "$schema": "http://json-schema.org/schema#",
+  "title": "7/CMX config request schema",
 
-#### Semantics
+  "type": "object",
+  "properties": {
+    "configId": {
+      "type": "string",
+      "description": "Identifier of the currently applied configuration. Optional."
+    },
+    "observe": {
+      "type": "boolean",
+      "description": "Whether the endpoint is interested in observing its configuration."
+    }
+  },
+  "additionalProperties": false
+}
 
-If `configId` field is missing, the server MUST respond with the latest configuration for the given endpoint, or no configuration if none was assigned.
+```
 
-If `configId` field is present, the server MUST send new configuration only if `configId` differs from the currently assigned configuration identifier for the endpoint.
+If `configId` field is missing, the server MUST respond with the current configuration for the given endpoint.
+
+If `configId` field is present, the server MUST send new configuration only if `configId` differs from the identifier of the currently assigned cofiguration for the endpoint.
 
 If `observe` field is present and is `true`, the server MUST send new configuration to the endpoint whenever configuration changes.
 
@@ -87,34 +115,139 @@ The server MAY send configurations to the endpoint when no request were done bef
 
 If the current config matches one specified by `configId` in the request, the server MUST return response with both `configId` and `config` absent.
 
+Examples:
+```json
+{
+  "configId": "97016dbe8bb4adff8f754ecbf24612f2"
+}
+```
+
+```json
+{
+  "observe": true
+}
+```
+
+### Response
+Response payload MUST be a UTF-8 encoded object with the JSON Scheme as defined in [config-response.schema.json](./config-response.schema.json) file.
+
+```json
+{
+  "$schema": "http://json-schema.org/schema#",
+  "title": "7/CMX config response schema",
+
+  "type": "object",
+  "properties": {
+    "configId": {
+      "type": "string",
+      "description": "Identifier of the current configuration."
+    },
+    "config": {
+      "description": "Configuration body of an arbitrary type (as set by the request `config_format`)."
+    }
+  },
+  "additionalProperties": false
+}
+```
+
+`configId` and `config` MUST come in a pair. If `configId` and `config` are absent in the response, that means configuration hasn't changed.
+
 If an endpoint successfully applies provided configuration, it SHOULD notify the server via `/applied` resource.
 
-### Applied resource
-`/<endpoint_token>/applied/json` resource is used by the endpoint to notify the server of successfully applied configuration.
+Examples:
+- configuration hasn't changed
+  ```json
+  {
+  }
+  ```
 
-The request is a JSON object with the following fields:
-- `configId` (required) - id of applied configuration.
+- new configuration
+  ```json
+  {
+    "configId": "97016dbe8bb4adff8f754ecbf24612f2",
+    "config": {
+      "mode": "AP",
+      "ssid": "Smart Teapot",
+      "password": "acupofteaplease",
+      "security": "WPA2_PSK"
+    }
+  }
+  ```
 
-The response is empty.
+## Applied resource
+Applied resource is used by endpoints to notify the server of successfully applied configuration.
 
-## Open questions
-### Merge resources
-The request to `/config` resource already includes all fields for `/applied` requests, so it might be possible to merge them in a single resource.
+The applied resource is a request/response resource with the following resource path:
+```
+/<endpoint_token>/applied
+```
 
-### Error handling
-Whaw errors are possible here? Should endpoint care?
+### Request
 
-### Configuration rejection
-Should it be possible for the endpoint to actively reject a configuration?
+The request is a UTF-8 encoded JSON object with the JSON Schema as defined in [applied-request.schema.json](./applied-request.schema.json) file.
 
-Examples are:
-- the endpoint is unable to process the configuration.
-- the configuration is ill-formated, or pre-conditions are not met.
+```json
+{
+  "$schema": "http://json-schema.org/schema#",
+  "title": "7/CMX applied request schema",
 
-### Subscribing to a part of configuration
+  "type": "object",
+  "properties": {
+    "configId": {
+      "type": "string",
+      "description": "Identifier of the applied configuration."
+    },
+    "statusCode": {
+      "type": "number",
+      "description": "Status code based on HTTP status codes.",
+      "default": 200
+    },
+    "reasonPhrase": {
+      "type": "string",
+      "description": "A human-readable string explaining the cause of an error (if any)."
+    }
+  },
+  "required": [ "configId" ],
+  "additionalProperties": false
+}
+```
+
+A request means the endpoint has received the given configuration and tried to apply it.
+
+`statusCode` represents a result of appliyng the configuration (either success or failure). If result is a failure, `reasonPhrase` SHOULD include a reason of the failure.
+
+Examples:
+- configuration successfully applied:
+  ```json
+  {
+    "configId": "97016dbe8bb4adff8f754ecbf24612f2"
+  }
+  ```
+
+- configuration is rejected
+  ```json
+  {
+    "configId": "97016dbe8bb4adff8f754ecbf24612f2",
+    "statusCode": 400,
+    "reasonPhrase": "WPA2 is not supported"
+  }
+  ```
+
+### Response
+
+The response payload MUST be empty.
+
+# Open questions
+## Merge resources
+The request to `/config` resource already includes most fields for `/applied` requests, so it might be possible to merge them in a single resource.
+
+## Error handling
+What errors are possible here? Should endpoint care?
+
+## Subscribing to a part of configuration
 This is still not addressed in this document.
 
-### Only send configuration difference
+## Only send configuration difference
 Minimizing network traffic by only sending a configuration difference is not addressed.
 
 On the other hand, we're sending JSONs, so there are other more efficient ways to minimize traffic by changing the format (e.g., use BSON, CBOR, MessagePack).

--- a/0007-configuration-management-extension/README.md
+++ b/0007-configuration-management-extension/README.md
@@ -91,7 +91,7 @@ Request payload MUST be a UTF-8 encoded object with the JSON Scheme as defined i
   "properties": {
     "configId": {
       "type": "string",
-      "description": "Identifier of the currently applied configuration. Optional."
+      "description": "Identifier of the currently applied configuration."
     },
     "observe": {
       "type": "boolean",
@@ -100,7 +100,6 @@ Request payload MUST be a UTF-8 encoded object with the JSON Scheme as defined i
   },
   "additionalProperties": false
 }
-
 ```
 
 If `configId` field is missing, the server MUST respond with the current configuration for the given endpoint.
@@ -116,17 +115,24 @@ The server MAY send configurations to the endpoint when no request were done bef
 If the current config matches one specified by `configId` in the request, the server MUST return response with both `configId` and `config` absent.
 
 Examples:
-```json
-{
-  "configId": "97016dbe8bb4adff8f754ecbf24612f2"
-}
-```
-
-```json
-{
-  "observe": true
-}
-```
+- get current configuration only
+  ```json
+  {
+    "observe": false
+  }
+  ```
+- endpoint's current config ID is `97016dbe8bb4adff8f754ecbf24612f2`.
+  ```json
+  {
+    "configId": "97016dbe8bb4adff8f754ecbf24612f2"
+  }
+  ```
+- subscribe to all configuration updates
+  ```json
+  {
+    "observe": true
+  }
+  ```
 
 ### Response
 Response payload MUST be a UTF-8 encoded object with the JSON Scheme as defined in [config-response.schema.json](./config-response.schema.json) file.
@@ -143,7 +149,7 @@ Response payload MUST be a UTF-8 encoded object with the JSON Scheme as defined 
       "description": "Identifier of the current configuration."
     },
     "config": {
-      "description": "Configuration body of an arbitrary type (as set by the request `config_format`)."
+      "description": "Configuration body of an arbitrary type."
     }
   },
   "additionalProperties": false

--- a/0007-configuration-management-extension/applied-request.schema.json
+++ b/0007-configuration-management-extension/applied-request.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "title": "7/CMX applied request schema",
+
+  "type": "object",
+  "properties": {
+    "configId": {
+      "type": "string",
+      "description": "Identifier of the applied configuration."
+    },
+    "statusCode": {
+      "type": "number",
+      "description": "Status code based on HTTP status codes.",
+      "default": 200
+    },
+    "reasonPhrase": {
+      "type": "string",
+      "description": "A human-readable string explaining the cause of an error (if any)."
+    }
+  },
+  "required": [ "configId" ],
+  "additionalProperties": false
+}

--- a/0007-configuration-management-extension/config-request.schema.json
+++ b/0007-configuration-management-extension/config-request.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "title": "7/CMX config request schema",
+
+  "type": "object",
+  "properties": {
+    "configId": {
+      "type": "string",
+      "description": "Identifier of the currently applied configuration."
+    },
+    "observe": {
+      "type": "boolean",
+      "description": "Whether the endpoint is interested in observing its configuration."
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
1/KP has moved request id to the topic name and has defined a common
format for error responses.

Update 7/CMX to incorporate the changes.